### PR TITLE
Fix CI Tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Ruby ${{ matrix.ruby }}, Gemfile ${{ matrix.gemfile }}
     strategy:
+      fail-fast: false
       matrix:
         gemfile: [ current, jekyll3 ]
         ruby: [ '3.1', '3.3' ]
@@ -20,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libblas3 liblapack3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Ubuntu on the GitHub Runner is missing a dependency required for the VSS extension. Install it as part of our setup.